### PR TITLE
Try to avoid of double promote

### DIFF
--- a/governor.py
+++ b/governor.py
@@ -88,6 +88,8 @@ def main():
     try:
         governor.initialize()
         governor.run()
+    except KeyboardInterrupt:
+        pass
     finally:
         governor.touch_member(300)  # schedule member removal
         governor.postgresql.stop()

--- a/helpers/ha.py
+++ b/helpers/ha.py
@@ -48,10 +48,10 @@ class Ha:
             if self.cluster.is_unlocked():
                 if self.state_handler.is_healthiest_node(self.cluster):
                     if self.acquire_lock():
-                        if not self.state_handler.is_leader():
-                            self.state_handler.promote()
-                            return 'promoted self to leader by acquiring session lock'
-                        return 'acquired session lock as a leader'
+                        if self.state_handler.is_leader() or self.state_handler.is_promoted:
+                            return 'acquired session lock as a leader'
+                        self.state_handler.promote()
+                        return 'promoted self to leader by acquiring session lock'
                     else:
                         self.load_cluster_from_etcd()
                         if self.state_handler.is_leader():
@@ -71,14 +71,13 @@ class Ha:
             else:
                 if self.has_lock() and self.update_lock():
                     try:
-                        if not self.state_handler.is_leader():
-                            self.state_handler.promote()
-                            return 'promoted self to leader because i had the session lock'
-                        else:
+                        if self.state_handler.is_leader() or self.state_handler.is_promoted:
                             return 'no action.  i am the leader with the lock'
+                        self.state_handler.promote()
+                        return 'promoted self to leader because i had the session lock'
                     finally:
                         # create replication slots
-                        self.state_handler.create_replication_slots([m.hostname for m in self.cluster.members])
+                        self.state_handler.create_replication_slots(self.cluster)
                 else:
                     logger.info('does not have lock')
                     if self.state_handler.is_leader():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,10 +11,6 @@ else:
     from StringIO import StringIO as IO
 
 
-def false(*args, **kwargs):
-    return False
-
-
 def throws(*args, **kwargs):
     raise psycopg2.OperationalError()
 
@@ -48,7 +44,7 @@ class MockRestApiServer(RestApiServer):
     def __init__(self, Handler, path, *args):
         self.governor = MockGovernor()
         if len(args) > 0:
-            self.governor.postgresql.is_running = args[0]
+            self._cursor = args[0]
         self._cursor_holder = None
         Handler(MockRequest(path), ('0.0.0.0', 8080), self)
 
@@ -61,6 +57,3 @@ class TestRestApiHandler(unittest.TestCase):
     def test_do_GET(self):
         MockRestApiServer(RestApiHandler, b'GET /')
         MockRestApiServer(RestApiHandler, b'GET /', throws)
-
-    def test_get_postgresql_status(self):
-        MockRestApiServer(RestApiHandler, b'GET /', false)

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -19,6 +19,7 @@ class MockPostgresql:
 
     def __init__(self):
         self.name = 'postgresql0'
+        self.is_promoted = False
 
     def is_healthy(self):
         return True

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -15,7 +15,7 @@ def nop(*args, **kwargs):
     pass
 
 
-def subprocess_call(cmd, shell=False):
+def subprocess_call(cmd, shell=False, env=None):
     return 0
 
 
@@ -110,17 +110,13 @@ class TestPostgresql(unittest.TestCase):
     def set_up(self):
         subprocess.call = subprocess_call
         shutil.copy = nop
-        self.p = Postgresql({
-            'name': 'test0',
-            'data_dir': 'data/test0',
-            'listen': '127.0.0.1, 127.0.0.2:5432',
-            'connect_address': '127.0.0.2:5432',
-            'superuser': {'password': ''},
-            'admin': {'username': 'admin', 'password': 'admin'},
-            'replication': {'username': 'replicator', 'password': 'rep-pass', 'network': '127.0.0.1/32'},
-            'parameters': {'foo': 'bar'},
-            'recovery_conf': {'foo': 'bar'},
-        })
+        self.p = Postgresql({'name': 'test0', 'data_dir': 'data/test0', 'listen': '127.0.0.1, 127.0.0.2:5432',
+                             'connect_address': '127.0.0.2:5432', 'superuser': {'password': ''},
+                             'admin': {'username': 'admin', 'password': 'admin'},
+                             'replication': {'username': 'replicator',
+                                             'password': 'rep-pass',
+                                             'network': '127.0.0.1/32'},
+                             'parameters': {'foo': 'bar'}, 'recovery_conf': {'foo': 'bar'}})
         psycopg2.connect = psycopg2_connect
         if not os.path.exists(self.p.data_dir):
             os.makedirs(self.p.data_dir)
@@ -155,7 +151,10 @@ class TestPostgresql(unittest.TestCase):
 
     def test_create_replication_slots(self):
         self.p.start()
-        self.p.create_replication_slots('qaz')
+        me = Member('test0', 'postgres://replicator:rep-pass@127.0.0.1:5434/postgres', 28)
+        other = Member('test1', 'postgres://replicator:rep-pass@127.0.0.1:5433/postgres', 28)
+        cluster = Cluster(True, self.leader, 0, [me, other, self.leader])
+        self.p.create_replication_slots(cluster)
 
     def test_query(self):
         self.p.query('select 1')
@@ -181,7 +180,9 @@ class TestPostgresql(unittest.TestCase):
         self.assertFalse(self.p.is_healthiest_node(cluster))
 
     def test_is_leader(self):
+        self.p.is_promoted = True
         self.assertTrue(self.p.is_leader())
+        self.assertFalse(self.p.is_promoted)
 
     def test_reload(self):
         self.assertTrue(self.p.reload())


### PR DESCRIPTION
Postgresql object aware of the fact that instance has been promoted to the master. Flag (is_promoted) would be reset when pg_is_in_recovery() will start returning False.

Remove trigger_file:
* after promote finished (pg_is_in_recovery() = False) if it hasn't been removed automatically.
* on slave, after execution of pg_basebackup

Small improvement of api: first try to execute query and only if it failed check postgres status with "is_running" call.

Plus small bugfix: do not create unneeded replication slot for master on master